### PR TITLE
[Feat/FE] 카카오 로그인 구현

### DIFF
--- a/frontend/petkinFE/app/build.gradle.kts
+++ b/frontend/petkinFE/app/build.gradle.kts
@@ -1,7 +1,14 @@
+import java.util.Properties
+
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsKotlinAndroid)
 }
+
+val properties = Properties()
+properties.load(rootProject.file("local.properties").inputStream())
+
 
 android {
     namespace = "com.rtl.petkinfe"
@@ -19,7 +26,20 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        buildConfigField(
+            "String",
+            "KAKAO_API_KEY",
+            "\"${properties["KAKAO_API_KEY"]}\""
+        )
+        resValue(
+            "string",
+            "KAKAO_REDIRECT_URI",
+            properties["KAKAO_REDIRECT_URI"].toString()
+        )
+
     }
+
+
 
     buildTypes {
         release {
@@ -39,6 +59,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
@@ -69,4 +90,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(libs.kakao.sdk.user)
 }

--- a/frontend/petkinFE/app/src/main/AndroidManifest.xml
+++ b/frontend/petkinFE/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".MyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -21,6 +22,22 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="oauth"
+                    android:scheme="@string/KAKAO_REDIRECT_URI" />
             </intent-filter>
         </activity>
     </application>

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/App.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/App.kt
@@ -1,12 +1,12 @@
 package com.rtl.petkinfe
 
 import androidx.compose.runtime.*
-import com.rtl.petkinfe.presentation.view.login.LoginView
+import com.rtl.petkinfe.presentation.view.login.LoginScreen
 import com.rtl.petkinfe.ui.theme.PetkinFETheme
 
 @Composable
 fun App(navigator: AppNavigator) {
     PetkinFETheme {
-        LoginView(navigator)
+        LoginScreen(navigator)
     }
 }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/AppNavigator.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/AppNavigator.kt
@@ -5,7 +5,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.rtl.petkinfe.presentation.view.home.HomeView
-import com.rtl.petkinfe.presentation.view.login.LoginView
+import com.rtl.petkinfe.presentation.view.login.LoginScreen
 
 interface AppNavigator {
     fun navigateToLogin()
@@ -23,11 +23,10 @@ fun AppNavigation() {
         startDestination = "login" // 시작 화면을 LoginView로 설정
     ) {
         composable("login") {
-            LoginView(navigator = object : AppNavigator {
+            LoginScreen(navigator = object : AppNavigator {
                 override fun navigateToLogin() {
-                    // 이미 LoginView에 있기 때문에 처리 없음
+                    TODO("Not yet implemented")
                 }
-
                 override fun navigateToHome() {
                     navController.navigate("home") // 홈 화면으로 이동
                 }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/MainActivity.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/MainActivity.kt
@@ -4,30 +4,27 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.collectAsState
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.rtl.petkinfe.presentation.view.login.LoginView
 import com.rtl.petkinfe.ui.theme.PetkinFETheme
 
 class MainActivity : ComponentActivity() {
     private val viewModel by viewModels<MainViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Splash Screen 설정
         installSplashScreen().apply {
-            // ToDO : check login status
             setKeepVisibleCondition {
-                !viewModel.isReady.value
+                !viewModel.isReady.value // ViewModel이 준비될 때까지 유지
             }
         }
+
+        // Kakao SDK 초기화 완료 여부 확인
         setContent {
             PetkinFETheme {
-                AppNavigation()
+                if (viewModel.isReady.collectAsState().value) {
+                    AppNavigation() // 초기화 후 Navigation 실행
+                }
             }
         }
     }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/MyApplication.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/MyApplication.kt
@@ -1,0 +1,14 @@
+package com.rtl.petkinfe
+
+import android.app.Application
+import android.util.Log
+import com.kakao.sdk.common.KakaoSdk
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        val kakaoAppKey = BuildConfig.KAKAO_API_KEY
+        Log.d("KakaoSDK", "App Key: $kakaoAppKey")
+        KakaoSdk.init(this, kakaoAppKey)
+    }
+}

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/presentation/view/login/LoginScreen.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/presentation/view/login/LoginScreen.kt
@@ -1,5 +1,7 @@
 package com.rtl.petkinfe.presentation.view.login
 
+import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -12,18 +14,25 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rtl.petkinfe.AppNavigator
 import com.rtl.petkinfe.R
 import com.rtl.petkinfe.ui.theme.SplashBackgroundColor
 
 
 @Composable
-fun LoginView(navigator: AppNavigator) {
+fun LoginScreen(navigator: AppNavigator) {
+    val viewModel: LoginViewModel = viewModel()
+    val context = LocalContext.current
+    val loginState by viewModel.loginState.collectAsState()
     Scaffold(
         containerColor = SplashBackgroundColor
     ) {
@@ -54,10 +63,25 @@ fun LoginView(navigator: AppNavigator) {
                     .size(width = 330.dp, height = 64.dp)
                     .clickable {
                         // 카카오 로그인 로직 추가
-                        navigator.navigateToHome()
+                        viewModel.loginWithKakao(context)
                     }
             )
         }
+    }
+
+    // 로그인 상태 처리
+    when (loginState) {
+        is LoginViewModel.LoginState.Success -> {
+            val token = (loginState as LoginViewModel.LoginState.Success).token
+            Log.d("LoginView", "로그인 성공! 토큰: $token")
+
+            // 로그인 성공 시 메인 화면으로 이동
+            navigator.navigateToHome()
+        }
+        is LoginViewModel.LoginState.Failure -> {
+            Toast.makeText(context, "로그인 실패", Toast.LENGTH_SHORT).show()
+        }
+        else -> {}
     }
 
 }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/presentation/view/login/LoginViewModel.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/presentation/view/login/LoginViewModel.kt
@@ -1,0 +1,38 @@
+package com.rtl.petkinfe.presentation.view.login
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import com.kakao.sdk.user.UserApiClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class LoginViewModel : ViewModel()
+{
+    private val _loginState = MutableStateFlow<LoginState>(LoginState.Idle)
+    val loginState: StateFlow<LoginState> = _loginState
+    fun loginWithKakao(context: Context) {
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                if (error != null) {
+                    _loginState.value = LoginState.Failure(error)
+                } else if (token != null) {
+                    _loginState.value = LoginState.Success(token.accessToken)
+                }
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+                if (error != null) {
+                    _loginState.value = LoginState.Failure(error)
+                } else if (token != null) {
+                    _loginState.value = LoginState.Success(token.accessToken)
+                }
+            }
+        }
+    }
+
+    sealed class LoginState {
+        object Idle : LoginState()
+        data class Success(val token: String) : LoginState()
+        data class Failure(val error: Throwable) : LoginState()
+    }
+}

--- a/frontend/petkinFE/build.gradle.kts
+++ b/frontend/petkinFE/build.gradle.kts
@@ -3,3 +3,4 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
 }
+

--- a/frontend/petkinFE/gradle/libs.versions.toml
+++ b/frontend/petkinFE/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ composeBom = "2023.08.00"
 navigationRuntimeKtx = "2.8.4"
 navigationCompose = "2.8.4"
 splashscreen = "1.0.0-alpha01"
+kakaoSdk = "2.20.6"
 
 [libraries]
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
@@ -30,6 +31,16 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# Kakao SDK
+kakao-sdk-all = { group = "com.kakao.sdk", name = "v2-all", version.ref = "kakaoSdk" }
+kakao-sdk-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
+kakao-sdk-share = { group = "com.kakao.sdk", name = "v2-share", version.ref = "kakaoSdk" }
+kakao-sdk-talk = { group = "com.kakao.sdk", name = "v2-talk", version.ref = "kakaoSdk" }
+kakao-sdk-friend = { group = "com.kakao.sdk", name = "v2-friend", version.ref = "kakaoSdk" }
+kakao-sdk-navi = { group = "com.kakao.sdk", name = "v2-navi", version.ref = "kakaoSdk" }
+kakao-sdk-cert = { group = "com.kakao.sdk", name = "v2-cert", version.ref = "kakaoSdk" }
+
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/frontend/petkinFE/settings.gradle.kts
+++ b/frontend/petkinFE/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven ("https://devrepo.kakao.com/nexus/content/groups/public/")
     }
 }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가


### 반영 브랜치
fea/kakaologin -> main

### 변경 사항
- `카카오 로그인` 버튼 클릭 시 카카오 로그인으로 이동

### 결과물

<img width="315" alt="스크린샷 2024-11-24 오후 11 56 22" src="https://github.com/user-attachments/assets/14728472-3269-4d4d-80b9-5129add4a715">
<img width="315" alt="스크린샷 2024-11-24 오후 11 56 26" src="https://github.com/user-attachments/assets/4c70a001-6055-4ec8-8f43-a1fb55a8a017">

### 주의 사항
- local.properties 에 api 키 등록해야함
