### PR TITLE
[Feature/FE] 홈화면 진입 시 기존 예측 결과 있다면 불러와서 띄우기 구현

### DIFF
--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/local/dao/PhotoDao.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/local/dao/PhotoDao.kt
@@ -21,6 +21,8 @@ interface PhotoDao {
     @Query("SELECT * FROM photos WHERE uri = :uri LIMIT 1")
     suspend fun getPhotoByUri(uri: String): Photo?
 
+    @Query("SELECT * FROM photos WHERE predictionId = :predictionId LIMIT 1")
+    suspend fun getPhotoByPredictionId(predictionId: Long): Photo?
 
     @Query(
         """

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/mapper/PredictionMapper.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/mapper/PredictionMapper.kt
@@ -1,13 +1,48 @@
 package com.rtl.petkinfe.data.mapper
 
-import com.rtl.petkinfe.data.remote.dto.PredictionResponseDto
+import com.rtl.petkinfe.data.remote.dto.PredictionDetailResponseDto
+import com.rtl.petkinfe.data.remote.dto.RequestPredictionResponseDto
 import com.rtl.petkinfe.domain.model.Prediction
 
-fun PredictionResponseDto.toDomain(): Prediction {
+
+fun RequestPredictionResponseDto.toDomain(): Prediction {
     return Prediction(
         analysisId = analysisId,
         analysisDate = analysisDate,
         predictedClassLabel = predictedClassLabel,
+        A1 = A1,
+        A2 = A2,
+        A3 = A3,
+        A4 = A4,
+        A5 = A5,
+        A6 = A6,
+        A7 = A7
+    )
+}
+
+fun PredictionDetailResponseDto.toDomain(timestamp: String): Prediction {
+    // A1~A7 값을 리스트로 묶기
+    val probabilities = listOf(A1, A2, A3, A4, A5, A6, A7)
+    val labels = listOf(
+        "구진/플라크",
+        "비듬/각질/상피성잔고리",
+        "태선화/과다색소침착",
+        "농포/여드름",
+        "미란/궤양",
+        "결정/종괴",
+        "무증상"
+    )
+
+    // 최대 확률값의 인덱스 가져오기
+    val maxIndex = probabilities.indexOf(probabilities.maxOrNull())
+
+    // 해당 인덱스에 대응하는 라벨 가져오기
+    val predictedLabel = if (maxIndex in labels.indices) labels[maxIndex] else "알 수 없음"
+
+    return Prediction(
+        analysisId = analysisId,
+        analysisDate = timestamp,
+        predictedClassLabel = predictedLabel, // 최대 확률값에 해당하는 라벨
         A1 = A1,
         A2 = A2,
         A3 = A3,

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/remote/api/PredictionApi.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/remote/api/PredictionApi.kt
@@ -1,7 +1,8 @@
 package com.rtl.petkinfe.data.remote.api
 
 import com.rtl.petkinfe.data.remote.dto.PredictionDetailResponseDto
-import com.rtl.petkinfe.data.remote.dto.PredictionResponseDto
+import com.rtl.petkinfe.data.remote.dto.PredictionRecordsResponseDto
+import com.rtl.petkinfe.data.remote.dto.RequestPredictionResponseDto
 import okhttp3.MultipartBody
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -18,12 +19,18 @@ interface PredictionApi {
     suspend fun requestDiseasePrediction(
         @Path("pet_id") petId: Long,
         @Part image: MultipartBody.Part
-    ): PredictionResponseDto
+    ): RequestPredictionResponseDto
 
     // 특정 날짜와 펫 ID를 기준으로 분석 기록 조회
-    @GET("api/ai/records/{pet_id}")
+    @GET("api/ai/predict/{pet_id}")
     suspend fun getRecordsByPetAndDate(
         @Path("pet_id") petId: Long,
         @Query("date") date: String
-    ): List<PredictionDetailResponseDto>
+    ): PredictionRecordsResponseDto
+
+    // 분석 ID 기반 분석 결과 조회
+    @GET("api/ai/predict-detail/{analysis_id}")
+    suspend fun getPredictionDetailById(
+        @Path("analysis_id") analysisId: Long
+    ): PredictionDetailResponseDto
 }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/remote/dto/PredictionDto.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/remote/dto/PredictionDto.kt
@@ -3,7 +3,7 @@ package com.rtl.petkinfe.data.remote.dto
 import com.google.gson.annotations.SerializedName
 import java.sql.Timestamp
 
-data class PredictionResponseDto(
+data class RequestPredictionResponseDto(
     @SerializedName("analysis_id")
     val analysisId: Long,
     @SerializedName("analysis_date")
@@ -19,7 +19,27 @@ data class PredictionResponseDto(
     val A7: Float
 )
 
+
 data class PredictionDetailResponseDto(
+    @SerializedName("analysis_id")
+    val analysisId: Long,
+    @SerializedName("model_name")
+    val modelName: String,
+    val accuracy: Float,
+    val A1: Float,
+    val A2: Float,
+    val A3: Float,
+    val A4: Float,
+    val A5: Float,
+    val A6: Float,
+    val A7: Float
+)
+
+data class PredictionRecordsResponseDto(
+    @SerializedName("predictions") val predictions: List<PredictionRecordResponseDto>
+)
+
+data class PredictionRecordResponseDto(
     @SerializedName("record_id")
     val recordId: Long,
     @SerializedName("pet_id")

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/repository/PetRepositoryImpl.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/data/repository/PetRepositoryImpl.kt
@@ -14,13 +14,11 @@ class PetRepositoryImpl @Inject constructor(
     private val sharedPrefManager: SharedPrefManager
 ): PetRepository {
     override suspend fun getMyPetList(): List<Pet> {
-        Log.d("펫등록", "getMyPetList 호출")
         return try {
             val response = petApi.getMyPets().toDomainModel()
             Log.d("펫등록", response.toString())
             response
         } catch (e: Exception) {
-            Log.e("펫등록", "getMyPetList 예외 발생: ${e.message}", e)
             emptyList() // 기본값 반환
         }
     }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/di/AppModule.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/di/AppModule.kt
@@ -6,8 +6,10 @@ import com.rtl.petkinfe.data.local.TokenDataSource
 import com.rtl.petkinfe.data.local.dao.PhotoDao
 import com.rtl.petkinfe.data.repository.AuthRepositoryImpl
 import com.rtl.petkinfe.domain.repository.AuthRepository
+import com.rtl.petkinfe.domain.repository.PetRepository
 import com.rtl.petkinfe.domain.repository.PredictionRepository
 import com.rtl.petkinfe.domain.usecases.AutoLoginUseCase
+import com.rtl.petkinfe.domain.usecases.GetTodayPredictionUseCase
 import com.rtl.petkinfe.domain.usecases.SavePhotoUseCase
 import dagger.Module
 import dagger.Provides
@@ -51,6 +53,14 @@ object AppModule {
     @Provides
     fun provideSavePhotoUseCase(predictionRepository: PredictionRepository): SavePhotoUseCase {
         return SavePhotoUseCase(predictionRepository)
+    }
+
+    @Provides
+    fun provideGetTodayPredictionUseCase(
+        petRepository: PetRepository,
+        predictionRepository: PredictionRepository
+    ): GetTodayPredictionUseCase {
+        return GetTodayPredictionUseCase(petRepository, predictionRepository)
     }
 
 }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/domain/model/Prediction.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/domain/model/Prediction.kt
@@ -15,16 +15,8 @@ data class Prediction(
     val A7: Float
 )
 
-data class PredictionDetail(
-    val modelName: String?,
-    val diseaseName: String?,
-    val A1: Double,
-    val A2: Double,
-    val A3: Double,
-    val A4: Double,
-    val A5: Double,
-    val A6: Double,
-    val A7: Double,
-    val predictionDate: String,
+data class PredictionWithImage(
+    val prediction: Prediction,
+    val imageUrl: String
 )
 

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/domain/repository/PredictionRepository.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/domain/repository/PredictionRepository.kt
@@ -1,11 +1,13 @@
 package com.rtl.petkinfe.domain.repository
 
 import com.rtl.petkinfe.domain.model.Prediction
-import com.rtl.petkinfe.domain.model.PredictionDetail
+import com.rtl.petkinfe.domain.model.PredictionWithImage
 import java.io.File
+import java.time.LocalDate
 
 interface PredictionRepository {
     suspend fun requestPrediction(petId: Long, imageFile: File): Prediction
-    fun getPredictionById(analysisId: Long): PredictionDetail
+    fun getPredictionById(analysisId: Long): Prediction
     suspend fun savePhoto(imageFile: File): String
+    suspend fun getPredictionsByDate(petId: Long, date: LocalDate): PredictionWithImage?
 }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/domain/usecases/GetTodayPredictionUseCase.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/domain/usecases/GetTodayPredictionUseCase.kt
@@ -1,9 +1,18 @@
 package com.rtl.petkinfe.domain.usecases
 
+import com.rtl.petkinfe.domain.model.Prediction
+import com.rtl.petkinfe.domain.model.PredictionWithImage
+import com.rtl.petkinfe.domain.repository.PetRepository
+import com.rtl.petkinfe.domain.repository.PredictionRepository
+import java.time.LocalDate
 import javax.inject.Inject
 
-class GetTodayPredictionUseCase @Inject constructor() {
-    fun execute() {
-        // 오늘의 피부 질환 기록 있으면 가져오기
+class GetTodayPredictionUseCase @Inject constructor(
+    private val petRepository: PetRepository,
+    private val predictionRepository: PredictionRepository
+) {
+    suspend fun execute(): PredictionWithImage? {
+        val petId = petRepository.getSavedPetId() ?: return null
+        return predictionRepository.getPredictionsByDate(petId, LocalDate.now())
     }
 }

--- a/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/presentation/view/core/CardSection.kt
+++ b/frontend/petkinFE/app/src/main/java/com/rtl/petkinfe/presentation/view/core/CardSection.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.rememberImagePainter
+import com.rtl.petkinfe.BuildConfig.API_BASE_URL
+
 import com.rtl.petkinfe.R
 import com.rtl.petkinfe.domain.model.ItemType
 import com.rtl.petkinfe.presentation.view.home.CardState
@@ -369,4 +371,25 @@ fun ExpandableCard(
             }
         }
     }
+}
+
+@Composable
+fun RenderPredictionImage(imageUrl: String) {
+    val baseUrl = API_BASE_URL.removeSuffix("/") // 마지막 "/" 제거
+    val fullImageUrl = "$baseUrl$imageUrl"
+    Log.d("testt", "fullImageUrl: $fullImageUrl")
+    Image(
+        painter = rememberImagePainter(
+            data = fullImageUrl,
+            builder = {
+                placeholder(R.drawable.res_dog) // 로딩 중 표시할 이미지
+                error(R.drawable.res_dog)           // 로드 실패 시 표시할 이미지
+            }
+        ),
+        contentDescription = "Prediction Image",
+        modifier = Modifier
+            .size(200.dp) // 이미지 크기 조정
+            .padding(8.dp),
+        contentScale = ContentScale.Crop
+    )
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가



### 반영 브랜치
- fe/record -> main

### 변경 사항
- 홈화면 진입 시 기존 예측 결과 있다면 불러와서 띄우기 구현했습니다.
- 테스트용 잘못 올라간 사진 파일들은 다음 업데이트 시 삭제 및 git 에 안올라가도록 수정하겠습니다

### 결과물
- UI 적으로 동일 내부 데이터 처리
